### PR TITLE
Added options to go-git PlainOpen to support opening a worktree.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -370,7 +370,10 @@ func runGits() {
 		}
 
 		// Open the repository.
-		repo, err := git.PlainOpen(repoPath)
+		repo, err := git.PlainOpenWithOptions(repoPath, &git.PlainOpenOptions{
+			DetectDotGit:          true,
+			EnableDotGitCommonDir: true,
+		})
 		panicIfError(err)
 
 		// Get the HEAD commit.


### PR DESCRIPTION
Fixes Does not work inside a Worktree. #18